### PR TITLE
fix hook NoneType error on new version of ComfyUI

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -158,6 +158,8 @@ def hook_all(restore=False, hooks=None):
         ]
     for key, module in sys.modules.items():
         for hook in hooks:
+            if hook is None:
+                continue
             if key == hook.module_name or key.endswith(hook.module_name_path):
                 if _hasattr(module, hook.target):
                     if not _hasattr(module, hook.orig_key):


### PR DESCRIPTION
On the new version of ComfyUI I got this error:

`Traceback (most recent call last):
  File "/resources/repos/ComfyUI/nodes.py", line 1879, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/resources/repos/ComfyUI/custom_nodes/ComfyUI-TiledDiffusion/__init__.py", line 1, in <module>
    from .tiled_diffusion import NODE_CLASS_MAPPINGS as TD_NCM, NODE_DISPLAY_NAME_MAPPINGS as TD_NDCM
  File "/resources/repos/ComfyUI/custom_nodes/ComfyUI-TiledDiffusion/tiled_diffusion.py", line 571, in <module>
    hook_all()
  File "/resources/repos/ComfyUI/custom_nodes/ComfyUI-TiledDiffusion/utils.py", line 161, in hook_all
    if key == hook.module_name or key.endswith(hook.module_name_path):
AttributeError: 'NoneType' object has no attribute 'module_name'`

So I just bypass the error if the hook is None.