### PR TITLE
Fix tiled conditioning for Flux.2 auxiliary latents and align scaled bbox weights

### DIFF
--- a/tiled_diffusion.py
+++ b/tiled_diffusion.py
@@ -203,6 +203,25 @@ class AbstractDiffusion:
         else:
             self.x_buffer.zero_()
 
+    def _tile_tensor_condition(self, v: Tensor, x_in: Tensor, x_tile: Tensor, bboxes, batch_id: int, get_bboxes_fn: Callable[[Tensor], List[List[BBox]]]) -> Tensor:
+        if v.ndim == 4:
+            bboxes_ = bboxes
+            if v.shape[-2:] != x_in.shape[-2:]:
+                bboxes_ = get_bboxes_fn(v)
+            v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]], dim=0)
+        if v.ndim > 0 and v.shape[0] != x_tile.shape[0]:
+            v = repeat_to_batch_size(v, x_tile.shape[0])
+        return v
+
+    def _tile_condition_value(self, v, x_in: Tensor, x_tile: Tensor, bboxes, batch_id: int, get_bboxes_fn: Callable[[Tensor], List[List[BBox]]]):
+        if isinstance(v, torch.Tensor):
+            return self._tile_tensor_condition(v, x_in, x_tile, bboxes, batch_id, get_bboxes_fn)
+        if isinstance(v, list):
+            return [self._tile_condition_value(item, x_in, x_tile, bboxes, batch_id, get_bboxes_fn) for item in v]
+        if isinstance(v, tuple):
+            return tuple(self._tile_condition_value(item, x_in, x_tile, bboxes, batch_id, get_bboxes_fn) for item in v)
+        return v
+
     @grid_bbox
     def init_grid_bbox(self, tile_w:int, tile_h:int, overlap:int, tile_bs:int):
         # if self._init_grid_bbox is not None: return
@@ -497,26 +516,20 @@ class MultiDiffusion(AbstractDiffusion):
                 x_tile = torch.cat([x_in[bbox.slicer] for bbox in bboxes], dim=0)   # [TB, C, TH, TW]
                 t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])
                 c_tile = {}
+                def get_bboxes_for_tensor(v: Tensor):
+                    cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                    return self.get_grid_bbox(
+                        self.width // cf,
+                        self.height // cf,
+                        self.overlap // cf,
+                        self.tile_batch_size,
+                        v.shape[-1],
+                        v.shape[-2],
+                        x_in.device,
+                        self.get_tile_weights,
+                    )
                 for k, v in c_in.items():
-                    if isinstance(v, torch.Tensor):
-                        if len(v.shape) == len(x_tile.shape):
-                            bboxes_ = bboxes
-                            if v.shape[-2:] != x_in.shape[-2:]:
-                                cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
-                                bboxes_ = self.get_grid_bbox(
-                                    self.width // cf,
-                                    self.height // cf,
-                                    self.overlap // cf,
-                                    self.tile_batch_size,
-                                    v.shape[-1],
-                                    v.shape[-2],
-                                    x_in.device,
-                                    self.get_tile_weights,
-                                )
-                            v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]])
-                        if v.shape[0] != x_tile.shape[0]:
-                            v = repeat_to_batch_size(v, x_tile.shape[0])
-                    c_tile[k] = v
+                    c_tile[k] = self._tile_condition_value(v, x_in, x_tile, bboxes, batch_id, get_bboxes_for_tensor)
 
                 # controlnet tiling
                 # self.switch_controlnet_tensors(batch_id, N, len(bboxes))
@@ -648,29 +661,41 @@ class SpotDiffusion(AbstractDiffusion):
                 x_tile = torch.cat([x_in[bbox.slicer] for bbox in bboxes], dim=0)   # [TB, C, TH, TW]
                 t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])
                 c_tile = {}
-                for k, v in c_in.items():
+                def get_bboxes_for_tensor(v: Tensor):
+                    cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                    return self.get_grid_bbox(
+                        self.width // cf,
+                        self.height // cf,
+                        self.overlap // cf,
+                        self.tile_batch_size,
+                        v.shape[-1],
+                        v.shape[-2],
+                        x_in.device,
+                        self.get_tile_weights,
+                    )
+                def tile_spot_value(v):
+                    if isinstance(v, torch.Tensor) and v.ndim == 4:
+                        bboxes_ = bboxes
+                        sh_h_new, sh_w_new = sh_h, sh_w
+                        if v.shape[-2:] != x_in.shape[-2:]:
+                            cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                            bboxes_ = get_bboxes_for_tensor(v)
+                            sh_h_new, sh_w_new = round(sh_h * self.compression / cf), round(sh_w * self.compression / cf)
+                        v = v.roll(shifts=(sh_h_new, sh_w_new), dims=(-2,-1))
+                        v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]], dim=0)
+                    if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] != x_tile.shape[0]:
+                        v = repeat_to_batch_size(v, x_tile.shape[0])
+                    return v
+                def tile_spot_condition_value(v):
                     if isinstance(v, torch.Tensor):
-                        if len(v.shape) == len(x_tile.shape):
-                            bboxes_ = bboxes
-                            sh_h_new, sh_w_new = sh_h, sh_w
-                            if v.shape[-2:] != x_in.shape[-2:]:
-                                cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
-                                bboxes_ = self.get_grid_bbox(
-                                    self.width // cf,
-                                    self.height // cf,
-                                    self.overlap // cf,
-                                    self.tile_batch_size,
-                                    v.shape[-1],
-                                    v.shape[-2],
-                                    x_in.device,
-                                    self.get_tile_weights,
-                                )
-                                sh_h_new, sh_w_new = round(sh_h * self.compression / cf), round(sh_w * self.compression / cf)
-                            v = v.roll(shifts=(sh_h_new, sh_w_new), dims=(-2,-1))
-                            v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]])
-                        if v.shape[0] != x_tile.shape[0]:
-                            v = repeat_to_batch_size(v, x_tile.shape[0])
-                    c_tile[k] = v
+                        return tile_spot_value(v)
+                    if isinstance(v, list):
+                        return [tile_spot_condition_value(item) for item in v]
+                    if isinstance(v, tuple):
+                        return tuple(tile_spot_condition_value(item) for item in v)
+                    return v
+                for k, v in c_in.items():
+                    c_tile[k] = tile_spot_condition_value(v)
 
                 # controlnet tiling
                 # self.switch_controlnet_tensors(batch_id, N, len(bboxes))
@@ -771,26 +796,22 @@ class MixtureOfDiffusers(AbstractDiffusion):
                 x_tile = torch.cat(x_tile_list, dim=0)                     # differs each
                 t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])   # just repeat
                 c_tile = {}
+                def get_bboxes_for_tensor(v: Tensor):
+                    cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                    tile_w = self.width // cf
+                    tile_h = self.height // cf
+                    return self.get_grid_bbox(
+                        tile_w,
+                        tile_h,
+                        self.overlap // cf,
+                        self.tile_batch_size,
+                        v.shape[-1],
+                        v.shape[-2],
+                        x_in.device,
+                        lambda: self.get_weight(tile_w, tile_h),
+                    )
                 for k, v in c_in.items():
-                    if isinstance(v, torch.Tensor):
-                        if len(v.shape) == len(x_tile.shape):
-                            bboxes_ = bboxes
-                            if v.shape[-2:] != x_in.shape[-2:]:
-                                cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
-                                bboxes_ = self.get_grid_bbox(
-                                    (tile_w := self.width // cf),
-                                    (tile_h := self.height // cf),
-                                    self.overlap // cf,
-                                    self.tile_batch_size,
-                                    v.shape[-1],
-                                    v.shape[-2],
-                                    x_in.device,
-                                    lambda: self.get_weight(tile_w, tile_h),
-                                )
-                            v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]])
-                        if v.shape[0] != x_tile.shape[0]:
-                            v = repeat_to_batch_size(v, x_tile.shape[0])
-                    c_tile[k] = v
+                    c_tile[k] = self._tile_condition_value(v, x_in, x_tile, bboxes, batch_id, get_bboxes_for_tensor)
                 
                 # controlnet
                 # self.switch_controlnet_tensors(batch_id, N, len(bboxes), is_denoise=True)

--- a/tiled_diffusion.py
+++ b/tiled_diffusion.py
@@ -514,7 +514,9 @@ class MultiDiffusion(AbstractDiffusion):
 
                 # batching & compute tiles
                 x_tile = torch.cat([x_in[bbox.slicer] for bbox in bboxes], dim=0)   # [TB, C, TH, TW]
-                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])
+                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0]).to(
+                    device=x_tile.device, non_blocking=True
+                )
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
@@ -661,7 +663,9 @@ class SpotDiffusion(AbstractDiffusion):
 
                 # batching & compute tiles
                 x_tile = torch.cat([x_in[bbox.slicer] for bbox in bboxes], dim=0)   # [TB, C, TH, TW]
-                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])
+                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0]).to(
+                    device=x_tile.device, non_blocking=True
+                )
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
@@ -798,7 +802,9 @@ class MixtureOfDiffusers(AbstractDiffusion):
                     x_tile_list.append(x_in[bbox.slicer])
 
                 x_tile = torch.cat(x_tile_list, dim=0)                     # differs each
-                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0])   # just repeat
+                t_tile = repeat_to_batch_size(t_in, x_tile.shape[0]).to(
+                    device=x_tile.device, non_blocking=True
+                )   # just repeat
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor

--- a/tiled_diffusion.py
+++ b/tiled_diffusion.py
@@ -205,10 +205,10 @@ class AbstractDiffusion:
 
     def _tile_tensor_condition(self, v: Tensor, x_in: Tensor, x_tile: Tensor, bboxes, batch_id: int, get_bboxes_fn: Callable[[Tensor], List[List[BBox]]]) -> Tensor:
         if v.ndim == 4:
-            bboxes_ = bboxes
+            tile_bboxes = bboxes
             if v.shape[-2:] != x_in.shape[-2:]:
-                bboxes_ = get_bboxes_fn(v)
-            v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]], dim=0)
+                tile_bboxes = get_bboxes_fn(v)[batch_id]
+            v = torch.cat([v[bbox.slicer] for bbox in tile_bboxes], dim=0)
         if v.ndim > 0 and v.shape[0] != x_tile.shape[0]:
             v = repeat_to_batch_size(v, x_tile.shape[0])
         return v
@@ -675,14 +675,14 @@ class SpotDiffusion(AbstractDiffusion):
                     )
                 def tile_spot_value(v):
                     if isinstance(v, torch.Tensor) and v.ndim == 4:
-                        bboxes_ = bboxes
+                        tile_bboxes = bboxes
                         sh_h_new, sh_w_new = sh_h, sh_w
                         if v.shape[-2:] != x_in.shape[-2:]:
                             cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
-                            bboxes_ = get_bboxes_for_tensor(v)
+                            tile_bboxes = get_bboxes_for_tensor(v)[batch_id]
                             sh_h_new, sh_w_new = round(sh_h * self.compression / cf), round(sh_w * self.compression / cf)
                         v = v.roll(shifts=(sh_h_new, sh_w_new), dims=(-2,-1))
-                        v = torch.cat([v[bbox_.slicer] for bbox_ in bboxes_[batch_id]], dim=0)
+                        v = torch.cat([v[bbox.slicer] for bbox in tile_bboxes], dim=0)
                     if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] != x_tile.shape[0]:
                         v = repeat_to_batch_size(v, x_tile.shape[0])
                     return v

--- a/tiled_diffusion.py
+++ b/tiled_diffusion.py
@@ -518,9 +518,11 @@ class MultiDiffusion(AbstractDiffusion):
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                    tile_w = min(self.width // cf, v.shape[-1])
+                    tile_h = min(self.height // cf, v.shape[-2])
                     return self.get_grid_bbox(
-                        self.width // cf,
-                        self.height // cf,
+                        tile_w,
+                        tile_h,
                         self.overlap // cf,
                         self.tile_batch_size,
                         v.shape[-1],
@@ -663,9 +665,11 @@ class SpotDiffusion(AbstractDiffusion):
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
+                    tile_w = min(self.width // cf, v.shape[-1])
+                    tile_h = min(self.height // cf, v.shape[-2])
                     return self.get_grid_bbox(
-                        self.width // cf,
-                        self.height // cf,
+                        tile_w,
+                        tile_h,
                         self.overlap // cf,
                         self.tile_batch_size,
                         v.shape[-1],
@@ -798,8 +802,8 @@ class MixtureOfDiffusers(AbstractDiffusion):
                 c_tile = {}
                 def get_bboxes_for_tensor(v: Tensor):
                     cf = x_in.shape[-1] * self.compression // v.shape[-1] # compression factor
-                    tile_w = self.width // cf
-                    tile_h = self.height // cf
+                    tile_w = min(self.width // cf, v.shape[-1])
+                    tile_h = min(self.height // cf, v.shape[-2])
                     return self.get_grid_bbox(
                         tile_w,
                         tile_h,


### PR DESCRIPTION
## Summary

This PR fixes tiled diffusion for Flux.2-style auxiliary latent inputs when `tile_batch_size > 1` and hardens alternate-resolution condition handling so effective bbox shapes stay aligned with the corresponding weight tensors.

Because the previous tiled-diffusion PR is still unmerged, this branch also contains those earlier commits. This PR description therefore covers the full combined changeset that is now present on the branch.

## Motivation

`tile_batch_size` is one of the main performance levers in this node, especially for larger models and upscale / cleanup workflows. However, with newer model APIs and Flux.2-style conditioning, increasing `tile_batch_size` above `1` could break tiled sampling entirely.

The tiled conditioning path previously only handled direct tensor values. That worked for older tensor-only cases, but newer conditioning layouts can carry image-like auxiliary inputs inside `list` / `tuple` containers, such as Flux.2-style `ref_latents`. In those cases, the main tile latent was expanded to the tile batch while auxiliary latent inputs were not tiled and batch-aligned the same way, which led to shape mismatches during sampling.

This PR makes the conditioning path robust for those auxiliary latent inputs while preserving existing behavior for the older direct-tensor path.

## Root cause

There were two separate issues:

1. **Nested auxiliary conditions were not tiled correctly**
   - The tiling logic only handled values that were directly `torch.Tensor` instances.
   - That missed cases where image-like conditions were stored inside `list` or `tuple` containers.
   - With Flux.2-style auxiliary latent inputs, `x_tile` was expanded to the tile batch while auxiliary image-like conditions such as `ref_latents` were not tiled and batch-aligned the same way.
   - This caused shape mismatches during model execution.

2. **Alternate-resolution bbox generation could disagree with weight size**
   - For alternate-resolution 4D condition tensors, bbox grids were generated at a scaled resolution.
   - In `MixtureOfDiffusers`, the gaussian weight tensor was built from the unclamped scaled tile size while `get_grid_bbox()` internally clamps the effective tile size to the condition tensor dimensions.
   - That could produce width / height mismatches between the effective bbox slice shape and the weight tensor shape.

## What changed

### Recursive condition tiling

Added shared helpers so tiled conditioning now supports:
- plain tensors
- lists of tensors
- tuples of tensors

New shared helpers:
- `_tile_tensor_condition(...)`
- `_tile_condition_value(...)`

This keeps the old direct-tensor behavior intact while extending the same logic to nested image-like condition values.

### Correct bbox handling for the current tile batch

Fixed the distinction between:
- the current batch’s `bboxes`, which are already a list of `BBox` objects
- the full batched output returned by `get_bboxes_for_tensor(...)`

The code now handles those two cases separately instead of treating them interchangeably.

### SpotDiffusion parity

Updated `SpotDiffusion` to apply the same recursive condition handling while preserving its existing shift / roll behavior.

### Scaled tile-size clamping for alternate-resolution conditions

Clamped scaled tile dimensions for alternate-resolution 4D condition tensors before calling `get_grid_bbox(...)`.

This is:
- a robustness cleanup in `MultiDiffusion`
- a robustness cleanup in `SpotDiffusion`
- a required fix in `MixtureOfDiffusers`, where gaussian weights must match the effective tile shape exactly

## Result

With these changes, tiled diffusion works correctly for Flux.2-style auxiliary latent inputs with `tile_batch_size > 1` instead of failing with batch and shape mismatches.

It also removes the alternate-resolution weight/bbox disagreement that could surface in weighted tiled paths when the scaled tile size exceeded the effective condition bounds.

## Testing

Tested with a Flux.2 Klein 9B workflow that previously failed whenever `tile_batch_size` was greater than `1`.

### Before
- batch mismatch errors during tiled sampling with Flux.2 auxiliary latent inputs
- follow-up shape mismatches in the alternate-resolution weighted path

### After
- tiled sampling runs correctly with the same workflow and `tile_batch_size > 1`

## Scope

This PR is intentionally limited to fixing 4D image-like auxiliary condition tiling and the associated scaled bbox / weight mismatch.

It does **not** attempt to add:
- broader 5D / video latent support
- model-family-specific behavior beyond making the current conditioning path robust for Flux.2-style auxiliary latents